### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import { BaseControl } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { F10 } from '@wordpress/keycodes';
+import domReady from '@wordpress/dom-ready';
 
 /**
  * External dependencies
@@ -48,11 +49,7 @@ class WysiwygControl extends Component {
 			suffix,
 		} );
 
-		if ( document.readyState === 'complete' ) {
-			this.initialize();
-		} else {
-			window.addEventListener( 'DOMContentLoaded', this.initialize );
-		}
+		domReady(() => this.initialize());
 	}
 
 	componentWillUnmount() {


### PR DESCRIPTION
@chrisvanpatten I'll be honest, I'm not sure why, but I was having issues with this loading in recent versions of Gutenberg. Running initialize when `readyState === interactive` fixes the issue (although I'm not sure how that's different from the DOMContentLoaded event). 

¯\_(ツ)_/¯ 